### PR TITLE
waffle.io Badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Stories in Ready](https://badge.waffle.io/v3rm0n/fratpos.png?label=ready&title=Ready)](https://waffle.io/v3rm0n/fratpos)
 # Fraternity Point of Sale system
 [![Build Status](https://travis-ci.org/v3rm0n/fratpos.png)](https://travis-ci.org/v3rm0n/fratpos)
 


### PR DESCRIPTION
Merge this to receive a badge indicating the number of issues in the ready column on your waffle.io board at https://waffle.io/v3rm0n/fratpos

This was requested by a real person (user v3rm0n) on waffle.io, we're not trying to spam you.
